### PR TITLE
better installation check

### DIFF
--- a/install_prereq.sh
+++ b/install_prereq.sh
@@ -1,6 +1,15 @@
 #!/bin/bash
 
-curl -sL https://deb.nodesource.com/setup_11.x | sudo -E bash -
+set -e
+
+which curl &> /dev/null || {
+    sudo apt-get update
+    sudo apt-get install -y curl
+}
+
+which node &> /dev/null || {
+    curl -sL https://deb.nodesource.com/setup_11.x | sudo -E bash -
+}
 
 sudo apt-get update
 sudo apt-get upgrade -y
@@ -8,6 +17,10 @@ sudo apt-get install -y dnsmasq hostapd screen curl python3-pip python3-setuptoo
 
 sudo pip3 install paho-mqtt pyaes tornado
 
+which npm &> /dev/null || {
+    echo "cannot find npm. please install nodejs manually."
+    exit 1
+}
 pushd scripts/smartconfig
 npm i
 popd


### PR DESCRIPTION
I had some problems because of missing curl in my fresh kali light install and also node did not installed out of the box, but the installscript finished with the message "ready". 
I added some checks before install and set bash in error-mode to stop if one command produced and error.