### PR TITLE
net-tools (ifconfig) missing on newer systems

### DIFF
--- a/install_prereq.sh
+++ b/install_prereq.sh
@@ -4,7 +4,7 @@ set -e
 
 sudo apt-get update
 sudo apt-get upgrade -y
-sudo apt-get install -y dnsmasq hostapd screen curl python3-pip python3-setuptools python3-wheel mosquitto haveged
+sudo apt-get install -y dnsmasq hostapd screen curl python3-pip python3-setuptools python3-wheel mosquitto haveged net-tools
 
 sudo pip3 install paho-mqtt pyaes tornado
 


### PR DESCRIPTION
On newer versions of Kali Linux and Debian, the package **net-tools** isn't included by default anymore. This leads to a not working wlan-ap since **ifconfig** is used to set up the wireless device in setup_ap.sh. 

This pull request adds net-tools to the list of packages to be installed by install_prereq.sh, so **ifconfig** works again to set up the vtrust-flash access point. 