### PR TITLE
Enable captive portal detection

### DIFF
--- a/scripts/fake-registration-server.py
+++ b/scripts/fake-registration-server.py
@@ -60,7 +60,7 @@ class FilesHandler(tornado.web.StaticFileHandler):
 
 class MainHandler(tornado.web.RequestHandler):
     def get(self):
-        self.write("Hello, world")
+        self.write("You are connected to vtrust-flash")
 
 class SchemaHandler(object):
     def __init__(self):

--- a/scripts/fake-registration-server.py
+++ b/scripts/fake-registration-server.py
@@ -239,6 +239,7 @@ def main():
             (r"/gw.json", JSONHandler),
             (r"/d.json", JSONHandler),
             ('/files/(.*)', FilesHandler, {'path': str('../files/')}),
+            (r".*", tornado.web.RedirectHandler, {"url": "http://10.42.42.1/", "permanent": False}),
         ],
         #template_path=os.path.join(os.path.dirname(__file__), "templates"),
         #static_path=os.path.join(os.path.dirname(__file__), "static"),


### PR DESCRIPTION
Adds a handler that responds to unknown requests with 302 (temporary redirect)

This should fix mobile devices that disconnect when there is no internet access