### PR TITLE
for debian buster aka 10.X

### DIFF
--- a/install_prereq.sh
+++ b/install_prereq.sh
@@ -5,6 +5,10 @@ set -e
 sudo apt-get update
 sudo apt-get upgrade -y
 sudo apt-get install -y dnsmasq hostapd screen curl python-pip python3-pip python-setuptools python3-setuptools python3-wheel python-dev python3-dev mosquitto haveged net-tools libssl-dev
+if [ $(grep -c '^10\.' /etc/debian_version 2>/dev/null ) = 1 ]
+then
+     apt-get install python-wheel
+fi
 sudo -H pip3 install paho-mqtt tornado git+https://github.com/M4dmartig4n/sslpsk.git pycrypto
 sudo -H pip2 install git+https://github.com/M4dmartig4n/sslpsk.git pycrypto
 


### PR DESCRIPTION
because we install some python 2.7 packages , we need python-wheel  to avoid 
a error when doing 
`sudo -H pip2 install git+https://github.com/M4dmartig4n/sslpsk.git pycrypto` 
