### PR TITLE
Added fix for iptables-legacy issue on latest Kali Linux

### DIFF
--- a/scripts/setup_ap.sh
+++ b/scripts/setup_ap.sh
@@ -3,6 +3,10 @@
 # Source config
 . ../config.txt
 
+if test -e /usr/sbin/iptables-legacy; then
+	iptables="/usr/sbin/iptables-legacy"
+fi
+
 if test -d /etc/NetworkManager; then
 	echo "Backing up NetworkManager.cfg..."
 	sudo cp /etc/NetworkManager/NetworkManager.conf /etc/NetworkManager/NetworkManager.conf.backup

--- a/stop_flash.sh
+++ b/stop_flash.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-
+killall wpa_supplicant
 echo "Stopping AP in a screen"
 sudo screen -S smarthack-wifi         -X stuff '^C'
 sudo screen -S smarthack-web          -X stuff '^C'


### PR DESCRIPTION
As documented in this: https://forums.kali.org/archive/index.php/t-43649.html

Kali Linux appears to create symlink from iptables to a new version, rather than iptables-legacy.

This patch tests for the existence of iptables-legacy and uses it instead.

Also added a killall wpa_supplicant to prevent issues with wpa_supplicant already being active when running the scripts.