### PR TITLE
Terminate arbitrary webservers before flashing

### DIFF
--- a/scripts/setup_ap.sh
+++ b/scripts/setup_ap.sh
@@ -3,24 +3,6 @@
 # Source config
 . ../config.txt
 
-check_config () {
-	if ! iw list | grep -q "* AP"; then
-		echo "AP mode not supported!"
-		echo "Please attach a WiFi card that supports AP mode."
-		exit 1
-	fi
-
-	echo -n "Checking for network interface $WLAN... "
-	if [ -e /sys/class/net/$WLAN ]; then
-		echo "Found."
-	else
-		echo "Not found!"
-		echo -n "Please edit WLAN in config.txt to one of: "
-		ls -m /sys/class/net
-		exit 1
-	fi
-}
-
 setup () {
 	wpa_supplicant_pid=$(pidof wpa_supplicant)
 	if [ -n "$wpa_supplicant_pid" ]; then
@@ -64,7 +46,6 @@ cleanup () {
 	fi
 }
 
-check_config
 trap cleanup EXIT
 setup
 

--- a/scripts/setup_checks.sh
+++ b/scripts/setup_checks.sh
@@ -3,6 +3,31 @@
 # Source config
 . ../config.txt
 
+check_eula () {
+	if [ ! -f eula_accepted ]; then
+		echo "======================================================"
+		echo "${bold}TUYA-CONVERT${normal}"
+		echo
+		echo "https://github.com/ct-Open-Source/tuya-convert"
+		echo "TUYA-CONVERT was developed by Michael Steigerwald from the IT security company VTRUST (https://www.vtrust.de/) in collaboration with the techjournalists Merlin Schumacher, Pina Merkert, Andrijan Moecker and Jan Mahn at c't Magazine. (https://www.ct.de/)"
+		echo 
+		echo 
+		echo "======================================================"
+		echo "${bold}PLEASE READ THIS CAREFULLY!${normal}"
+		echo "======================================================"
+		echo "TUYA-CONVERT creates a fake update server environment for ESP8266/85 based tuya devices. It enables you to backup your devices firmware and upload an alternative one (e.g. ESPEasy, Tasmota, Espurna) without the need to open the device and solder a serial connection (OTA, Over-the-air)."
+		echo "Please make sure that you understand the consequences of flashing an alternative firmware, since you might lose functionality!"
+		echo
+		echo "Flashing an alternative firmware can cause unexpected device behavior and/or render the device unusable. Be aware that you do use this software at YOUR OWN RISK! Please acknowledge that VTRUST and c't Magazine (or Heise Medien GmbH & Co. KG) CAN NOT be held accountable for ANY DAMAGE or LOSS OF FUNCTIONALITY by typing ${bold}yes + Enter${normal}"
+		echo 
+		read
+		if [ "$REPLY" != "yes" ]; then
+			exit
+		fi
+		touch eula_accepted
+	fi
+}
+
 check_config () {
 	if ! iw list | grep -q "* AP"; then
 		echo "AP mode not supported!"
@@ -50,6 +75,7 @@ check_port () {
 	fi
 }
 
+check_eula
 check_config
 check_port udp 53 "resolve DNS queries"
 check_port tcp 80 "answer HTTP requests"

--- a/scripts/setup_checks.sh
+++ b/scripts/setup_checks.sh
@@ -53,7 +53,7 @@ check_port () {
 	echo -n "Checking ${protocol^^} port $port... "
 	process_pid=$(sudo ss -Hlnp -A "$protocol" "sport = :$port" | grep -Po "(?<=pid=)(\d+)" | head -n1)
 	if [ -n "$process_pid" ]; then
-		process_name=$(sudo ps -p "$process_pid" -o comm=)
+		process_name=$(ps -p "$process_pid" -o comm=)
 		echo "Occupied by $process_name with PID $process_pid."
 		echo "Port $port is needed to $reason"
 		read -p "Do you wish to terminate $process_name? [y/N] " -n 1 -r
@@ -63,7 +63,7 @@ check_port () {
 			exit 1
 		else
 			echo "Attempting to terminate $process_name with PID $process_pid"
-			service=$(sudo ps -p "$process_pid" -o unit=)
+			service=$(ps -p "$process_pid" -o unit=)
 			if [ -n "$service" ]; then
 				sudo systemctl stop "$service"
 			else

--- a/scripts/setup_checks.sh
+++ b/scripts/setup_checks.sh
@@ -62,11 +62,12 @@ check_port () {
 			echo "Aborting due to occupied port"
 			exit 1
 		else
-			echo "Attempting to terminate $process_name with PID $process_pid"
 			service=$(ps -p "$process_pid" -o unit=)
 			if [ -n "$service" ]; then
+				echo "Attempting to stop $service"
 				sudo systemctl stop "$service"
 			else
+				echo "Attempting to terminate $process_name with PID $process_pid"
 				sudo kill -9 "$process_pid"
 				sudo tail --pid="$process_pid" -f /dev/null
 			fi

--- a/scripts/setup_checks.sh
+++ b/scripts/setup_checks.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+check_port () {
+	protocol="$1"
+	port="$2"
+	reason="$3"
+	echo -n "Checking ${protocol^^} port $port... "
+	process_pid=$(sudo ss -Hlnp -A "$protocol" "sport = :$port" | grep -Po "(?<=pid=)(\d+)" | head -n1)
+	if [ -n "$process_pid" ]; then
+		process_name=$(ps -p "$process_pid" -o comm=)
+		echo "Occupied by $process_name with PID $process_pid."
+		echo "Port $port is needed to $reason"
+		read -p "Do you wish to terminate $process_name? [y/N] " -n 1 -r
+		if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+			echo "Aborting due to occupied port"
+			exit 1
+		else
+			echo "Attempting to terminate $process_name with PID $process_pid"
+			service=$(sudo ps -p "$process_pid" -o unit | grep service)
+			if [ -n "$service" ]; then
+				sudo systemctl stop "$service"
+			else
+				sudo kill -9 "$process_pid"
+			fi
+			sleep 1
+		fi
+	else
+		echo "Available."
+	fi
+}
+
+check_port udp 53 "resolve DNS queries"
+check_port tcp 80 "answer HTTP requests"
+check_port tcp 443 "answer HTTPS requests"
+check_port tcp 1883 "run MQTT"
+check_port tcp 8886 "run MQTTS"
+

--- a/scripts/setup_checks.sh
+++ b/scripts/setup_checks.sh
@@ -79,8 +79,11 @@ check_port () {
 check_eula
 check_config
 check_port udp 53 "resolve DNS queries"
+check_port udp 67 "offer DHCP leases"
 check_port tcp 80 "answer HTTP requests"
 check_port tcp 443 "answer HTTPS requests"
+check_port udp 6666 "detect unencrypted Tuya firmware"
+check_port udp 6667 "detect encrypted Tuya firmware"
 check_port tcp 1883 "run MQTT"
 check_port tcp 8886 "run MQTTS"
 

--- a/scripts/setup_checks.sh
+++ b/scripts/setup_checks.sh
@@ -57,6 +57,7 @@ check_port () {
 		echo "Occupied by $process_name with PID $process_pid."
 		echo "Port $port is needed to $reason"
 		read -p "Do you wish to terminate $process_name? [y/N] " -n 1 -r
+		echo
 		if [[ ! $REPLY =~ ^[Yy]$ ]]; then
 			echo "Aborting due to occupied port"
 			exit 1

--- a/scripts/setup_checks.sh
+++ b/scripts/setup_checks.sh
@@ -67,9 +67,13 @@ check_port () {
 				echo "Attempting to stop $service"
 				sudo systemctl stop "$service"
 			else
-				echo "Attempting to terminate $process_name with PID $process_pid"
-				sudo kill -9 "$process_pid"
-				sudo tail --pid="$process_pid" -f /dev/null
+				echo "Attempting to terminate $process_name"
+				sudo kill "$process_pid"
+				if ! sudo timeout 10 tail --pid="$process_pid" -f /dev/null; then
+					echo "$process_name is still running after 10 seconds, sending SIGKILL"
+					sudo kill -9 "$process_pid"
+					sudo tail --pid="$process_pid" -f /dev/null
+				fi
 			fi
 			sleep 1
 		fi

--- a/scripts/setup_checks.sh
+++ b/scripts/setup_checks.sh
@@ -53,7 +53,7 @@ check_port () {
 	echo -n "Checking ${protocol^^} port $port... "
 	process_pid=$(sudo ss -Hlnp -A "$protocol" "sport = :$port" | grep -Po "(?<=pid=)(\d+)" | head -n1)
 	if [ -n "$process_pid" ]; then
-		process_name=$(ps -p "$process_pid" -o comm=)
+		process_name=$(sudo ps -p "$process_pid" -o comm=)
 		echo "Occupied by $process_name with PID $process_pid."
 		echo "Port $port is needed to $reason"
 		read -p "Do you wish to terminate $process_name? [y/N] " -n 1 -r

--- a/scripts/setup_checks.sh
+++ b/scripts/setup_checks.sh
@@ -1,5 +1,26 @@
 #!/bin/bash
 
+# Source config
+. ../config.txt
+
+check_config () {
+	if ! iw list | grep -q "* AP"; then
+		echo "AP mode not supported!"
+		echo "Please attach a WiFi card that supports AP mode."
+		exit 1
+	fi
+
+	echo -n "Checking for network interface $WLAN... "
+	if [ -e /sys/class/net/$WLAN ]; then
+		echo "Found."
+	else
+		echo "Not found!"
+		echo -n "Please edit WLAN in config.txt to one of: "
+		ls -m /sys/class/net
+		exit 1
+	fi
+}
+
 check_port () {
 	protocol="$1"
 	port="$2"
@@ -29,6 +50,7 @@ check_port () {
 	fi
 }
 
+check_config
 check_port udp 53 "resolve DNS queries"
 check_port tcp 80 "answer HTTP requests"
 check_port tcp 443 "answer HTTPS requests"

--- a/scripts/setup_checks.sh
+++ b/scripts/setup_checks.sh
@@ -67,6 +67,7 @@ check_port () {
 				sudo systemctl stop "$service"
 			else
 				sudo kill -9 "$process_pid"
+				sudo tail --pid="$process_pid" -f /dev/null
 			fi
 			sleep 1
 		fi

--- a/scripts/setup_checks.sh
+++ b/scripts/setup_checks.sh
@@ -63,7 +63,7 @@ check_port () {
 			exit 1
 		else
 			echo "Attempting to terminate $process_name with PID $process_pid"
-			service=$(sudo ps -p "$process_pid" -o unit | grep service)
+			service=$(sudo ps -p "$process_pid" -o unit=)
 			if [ -n "$service" ]; then
 				sudo systemctl stop "$service"
 			else

--- a/scripts/setup_checks.sh
+++ b/scripts/setup_checks.sh
@@ -62,7 +62,7 @@ check_port () {
 			echo "Aborting due to occupied port"
 			exit 1
 		else
-			service=$(ps -p "$process_pid" -o unit=)
+			service=$(ps -p "$process_pid" -o unit= | grep .service | grep -Ev ^user)
 			if [ -n "$service" ]; then
 				echo "Attempting to stop $service"
 				sudo systemctl stop "$service"

--- a/start_flash.sh
+++ b/start_flash.sh
@@ -44,8 +44,10 @@ while ! ping -c 1 -W 1 -n $GATEWAY &> /dev/null; do
 	printf .
 done
 echo
-echo "  Stopping any apache web server"
+echo "  Stopping any web server"
 sudo service apache2 stop >/dev/null 2>&1
+sudo service nginx stop >/dev/null 2>&1
+sudo kill -9 $(lsof -t -i:80 -i:443 -sTCP:LISTEN) >/dev/null 2>&1
 echo "  Starting web server in a screen"
 $screen_with_log smarthack-web.log -S smarthack-web -m -d ./fake-registration-server.py
 echo "  Starting Mosquitto in a screen"

--- a/start_flash.sh
+++ b/start_flash.sh
@@ -15,6 +15,8 @@ fi
 
 pushd scripts >/dev/null
 
+. ./setup_checks.sh
+
 echo "======================================================"
 echo -n "  Starting AP in a screen"
 $screen_with_log smarthack-wifi.log -S smarthack-wifi -m -d ./setup_ap.sh
@@ -22,15 +24,9 @@ while ! ping -c 1 -W 1 -n $GATEWAY &> /dev/null; do
 	printf .
 done
 echo
-echo "  Stopping any web server"
-sudo service apache2 stop >/dev/null 2>&1
-sudo service nginx stop >/dev/null 2>&1
-sudo kill -9 $(lsof -t -i:80 -i:443 -sTCP:LISTEN) >/dev/null 2>&1
 echo "  Starting web server in a screen"
 $screen_with_log smarthack-web.log -S smarthack-web -m -d ./fake-registration-server.py
 echo "  Starting Mosquitto in a screen"
-sudo service mosquitto stop >/dev/null 2>&1
-sudo pkill mosquitto
 $screen_with_log smarthack-mqtt.log -S smarthack-mqtt -m -d mosquitto -v
 echo "  Starting PSK frontend in a screen"
 $screen_with_log smarthack-psk.log -S smarthack-psk -m -d ./psk-frontend.py -v

--- a/start_flash.sh
+++ b/start_flash.sh
@@ -15,28 +15,6 @@ fi
 
 pushd scripts >/dev/null
 
-if [ ! -f eula_accepted ]; then
-	echo "======================================================"
-	echo "${bold}TUYA-CONVERT${normal}"
-	echo
-	echo "https://github.com/ct-Open-Source/tuya-convert"
-	echo "TUYA-CONVERT was developed by Michael Steigerwald from the IT security company VTRUST (https://www.vtrust.de/) in collaboration with the techjournalists Merlin Schumacher, Pina Merkert, Andrijan Moecker and Jan Mahn at c't Magazine. (https://www.ct.de/)"
-	echo 
-	echo 
-	echo "======================================================"
-	echo "${bold}PLEASE READ THIS CAREFULLY!${normal}"
-	echo "======================================================"
-	echo "TUYA-CONVERT creates a fake update server environment for ESP8266/85 based tuya devices. It enables you to backup your devices firmware and upload an alternative one (e.g. ESPEasy, Tasmota, Espurna) without the need to open the device and solder a serial connection (OTA, Over-the-air)."
-	echo "Please make sure that you understand the consequences of flashing an alternative firmware, since you might lose functionality!"
-	echo
-	echo "Flashing an alternative firmware can cause unexpected device behavior and/or render the device unusable. Be aware that you do use this software at YOUR OWN RISK! Please acknowledge that VTRUST and c't Magazine (or Heise Medien GmbH & Co. KG) CAN NOT be held accountable for ANY DAMAGE or LOSS OF FUNCTIONALITY by typing ${bold}yes + Enter${normal}"
-	echo 
-	read
-	if [ "$REPLY" != "yes" ]; then
-		exit
-	fi
-	touch eula_accepted
-fi
 echo "======================================================"
 echo -n "  Starting AP in a screen"
 $screen_with_log smarthack-wifi.log -S smarthack-wifi -m -d ./setup_ap.sh


### PR DESCRIPTION
I suggest to extend the pre-flashing shutdown of possibly running webservers to nginx and any other service that is occupying port 80 or 443.

Currently, `start_flash.sh` tries to stop only apache2. As it is widely used as an alternative and provided via mainline repositories, I propose to also gracefully end nginx. Just in case, ports 80 and 443 would be still used, e.g. by nodejs or any further service, they could be freed forcefully.

This commit might help in preventing issues that are raised by users who encounter binding errors with the fake registration server.