### PR TITLE
Replace ifconfig and explicitly add route to 10.42.42.0/24

### DIFF
--- a/scripts/setup_ap.sh
+++ b/scripts/setup_ap.sh
@@ -34,8 +34,10 @@ setup () {
 	fi
 
 	echo "Configuring AP interface..."
-	sudo ifconfig $WLAN down
-	sudo ifconfig $WLAN up $GATEWAY netmask 255.255.255.0
+	sudo ip link set $WLAN down
+	sudo ip addr add $GATEWAY/24 dev $WLAN
+	sudo ip link set $WLAN up
+	sudo ip route add 10.42.42.0/24 dev $WLAN src $GATEWAY
 	sudo ip route add 255.255.255.255 dev $WLAN
 
 	echo "Starting DNSMASQ server..."


### PR DESCRIPTION
This commit replaces deprecated `ifconfig` commands with their `ip` equivalents and ensures that a route to the subnet `10.42.42.0/24` is always created.

**Problem**
My setup involves a RPi 3, Debian Buster, Python 3, and an Internet/default route present at `eth0`. While trying to flash a smart plug, the log files showed that the device was connecting successfully to `vtrust-flash` and obtained an IP address via `dnsmasq`. However, flashing failed and the log files didn't include any connection attempt to the fake registration server or MQTT. It took me quite some time to figure out that the device that was given an 10.42.42.X IP address according to the logs was not actually reachable, neither by the DHCP-assigned address, nor at 10.42.42.42. 

Apparently, the problem was that `ip route` did not know how to handle 10.42.42.0/24 and preferred to let the `eth0` link deal with it rather than `wlan0`.  

**Solution**
Explicitly assign 10.42.42.0/24 to `wlan0`. Browsing through some issues, e.g., https://github.com/ct-Open-Source/tuya-convert/issues/194#issuecomment-492437295, some setups might do this automatically. Mine at least did not. After adding it manually, flashing worked. IMHO setting the route  always would do no harm either but could help in preventing similar problems that are unintuitive at first sight. I guess this might also solve issues, such as #348 or #317.