### PR TITLE
Deal with system dnsmasq

### DIFF
--- a/scripts/setup_ap.sh
+++ b/scripts/setup_ap.sh
@@ -58,9 +58,6 @@ cleanup () {
 	echo "Stopping DNSMASQ server..."
 	sudo pkill dnsmasq
 	
-	echo "Starting system DNSMASQ server..."
-	sudo service dnsmasq start
-
 	if test -d /etc/NetworkManager; then
 		echo "Restarting NetworkManager..."
 		sudo service network-manager restart

--- a/scripts/setup_ap.sh
+++ b/scripts/setup_ap.sh
@@ -58,7 +58,7 @@ cleanup () {
 	echo "Stopping DNSMASQ server..."
 	sudo pkill dnsmasq
 	
-	echo "Starting system DNSMASQ server...
+	echo "Starting system DNSMASQ server..."
 	sudo service dnsmasq start
 
 	if test -d /etc/NetworkManager; then

--- a/scripts/setup_ap.sh
+++ b/scripts/setup_ap.sh
@@ -57,6 +57,9 @@ cleanup () {
 
 	echo "Stopping DNSMASQ server..."
 	sudo pkill dnsmasq
+	
+	echo "Starting system DNSMASQ server...
+	sudo service dnsmasq start
 
 	if test -d /etc/NetworkManager; then
 		echo "Restarting NetworkManager..."

--- a/start_flash.sh
+++ b/start_flash.sh
@@ -38,6 +38,8 @@ if [ ! -f eula_accepted ]; then
 	touch eula_accepted
 fi
 echo "======================================================"
+echo -n "  Stopping system dnsmasq"
+sudo service dnsmasq stop >/dev/null 2>&1
 echo -n "  Starting AP in a screen"
 $screen_with_log smarthack-wifi.log -S smarthack-wifi -m -d ./setup_ap.sh
 while ! ping -c 1 -W 1 -n $GATEWAY &> /dev/null; do

--- a/start_flash.sh
+++ b/start_flash.sh
@@ -38,7 +38,7 @@ if [ ! -f eula_accepted ]; then
 	touch eula_accepted
 fi
 echo "======================================================"
-echo -n "  Stopping system dnsmasq"
+echo "  Stopping system dnsmasq"
 sudo service dnsmasq stop >/dev/null 2>&1
 echo -n "  Starting AP in a screen"
 $screen_with_log smarthack-wifi.log -S smarthack-wifi -m -d ./setup_ap.sh
@@ -85,6 +85,8 @@ while ! ping -c 1 -W 1 -n 10.42.42.42 &> /dev/null; do
 		pkill -f smartconfig/main.py && echo "Stopping smart config"
 		read -p "Do you want to try flashing another device? [y/N] " -n 1 -r
 		echo
+		sudo pkill dnsmasq && echo "Killing tuya-convert dnsmasq"
+		sudo service dnsmasq start && echo "System dnsmasq restarted"
 		continue 2
 	fi
 done


### PR DESCRIPTION
Someone on @digiblur 's chat seemed to run into a problem using the script which may or may not have been related to the system dnsmasq running instead of tuya-convert's dnsmasq config.

Not completely sure, but while investigating it I patched my local copy to shutdown the system dnsmasq before tuya-convert attempts to start its own.

Possible benefits:
- Deals with the system dnsmasq starting up after installation of the package and next time pi is rebooted for those on raspian on pi or other debian-based distros that start services as soon as they're installed.
- Makes sure the tuya-convert dhcp server is really running, which will make phones and other devices attaching to the wlan interface happier, perhaps. (?) 

Probably could be smarter but the main script is (knowingly) heavy handed with making sure stuff like apache isn't running, so I didn't get too wild with checking if the system one is really running, before attempting to stop it.  

I do NOT stop the tuya-convert dnsmasq if the script flashes the intermediate firmware successfully --because I assume MAYBE (even though most people will not), someone MIGHT somehow flash intermediate firmware that DHCPs or somehow their device might need a DHCP server at that time. Unlikely, but felt safer to leave tuya-convert version running there. Which means it'll be running until the script runs again or reboot.

Only stopping at the top of start_flash.sh prior to AP start up, and only switching back to system dnsmasq if we bomb out without a successful intermediate flash.

Tested on raspian buster fully patched as of Nov 2nd 2019. Additional testing appreciated.