### PR TITLE
Change shebang of psk-frontend.py to python2

### DIFF
--- a/scripts/psk-frontend.py
+++ b/scripts/psk-frontend.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import socket
 import select


### PR DESCRIPTION
psk-frontend.py should be executed with python2 until sslpsk is working with python3. Some distributions start defaulting to python3 which currently breaks this script.

See #365