### PR TITLE
Use ==/!= to compare str, bytes, and int literals

### DIFF
--- a/scripts/fake-registration-server.py
+++ b/scripts/fake-registration-server.py
@@ -250,7 +250,7 @@ def main():
         tornado.ioloop.IOLoop.current().start()
     except OSError as err:
         print("Could not start server on port " + str(options.port))
-        if err.errno is 98: # EADDRINUSE
+        if err.errno == 98: # EADDRINUSE
             print("Close the process on this port and try again")
         else:
             print(err)


### PR DESCRIPTION
Identity is not the same thing as equality in Python so use ==/!= to compare str, bytes, and int literals. In Python >= 3.8, these instances will raise SyntaxWarnings so it is best to fix them now.  https://docs.python.org/3.8/whatsnew/3.8.html#porting-to-python-3-8