### PR TITLE
Add backward compatibility for hostapd v2.5 and older (fix #398) 

### DIFF
--- a/scripts/setup_ap.sh
+++ b/scripts/setup_ap.sh
@@ -35,7 +35,7 @@ setup () {
 
 	# Read hostapd.conf with interface from stdin for
 	# backward compatibility (hostapd < v2.6). See #398
-	echo -e "`cat hostapd.conf`\ninterface=$WLAN" | sudo hostapd /dev/stdin
+	printf "$(cat hostapd.conf)\ninterface=$WLAN" | sudo hostapd /dev/stdin
 }
 
 cleanup () {

--- a/scripts/setup_ap.sh
+++ b/scripts/setup_ap.sh
@@ -32,7 +32,10 @@ setup () {
 		--address=/#/$GATEWAY
 
 	echo "Starting AP on $WLAN..."
-	sudo hostapd hostapd.conf -i $WLAN
+
+	# Read hostapd.conf with interface from stdin for
+	# backward compatibility (hostapd < v2.6). See #398
+	echo -e "`cat hostapd.conf`\ninterface=$WLAN" | sudo hostapd /dev/stdin
 }
 
 cleanup () {


### PR DESCRIPTION
Add the wifi interface to the hostapd.conf file and provide it via std in (instead of parameter `-i`). Fix for #398 

With improvements discussed in #404 