### PR TITLE
remove reference to merged and deleted tag

### DIFF
--- a/install_prereq.sh
+++ b/install_prereq.sh
@@ -5,6 +5,6 @@ set -e
 sudo apt-get update
 sudo apt-get install -y git iw dnsmasq hostapd screen curl build-essential python3-pip python3-setuptools python3-wheel python3-dev mosquitto haveged net-tools libssl-dev
 
-sudo -H python3 -m pip install --upgrade paho-mqtt tornado git+https://github.com/drbild/sslpsk.git@use-byte-string-for-identity-hints pycryptodomex
+sudo -H python3 -m pip install --upgrade paho-mqtt tornado git+https://github.com/drbild/sslpsk.git pycryptodomex
 
 echo "Ready to start upgrade"


### PR DESCRIPTION
The @use-byte-string-for-identity-hints tag was merged to master for https://github.com/drbild/sslpsk.git.
install_prereq.sh currently fails due to this.
Removing tag to fix this.