### PR TITLE
pin PyCryptodomex to version 3.9.4

### DIFF
--- a/install_prereq.sh
+++ b/install_prereq.sh
@@ -5,6 +5,6 @@ set -e
 sudo apt-get update
 sudo apt-get install -y git iw dnsmasq hostapd screen curl build-essential python3-pip python3-setuptools python3-wheel python3-dev mosquitto haveged net-tools libssl-dev
 
-sudo -H python3 -m pip install --upgrade paho-mqtt tornado git+https://github.com/drbild/sslpsk.git pycryptodomex
+sudo -H python3 -m pip install --upgrade paho-mqtt tornado git+https://github.com/drbild/sslpsk.git pycryptodomex==3.9.4
 
 echo "Ready to start upgrade"


### PR DESCRIPTION
The latest release of PyCryptodomex seems to be missing the Cryptodome.Util submodule, making the SmartConfig process fail. It works with the 3.9.4 version though.