### PR TITLE
Document why global pip install is used

### DIFF
--- a/install_prereq.sh
+++ b/install_prereq.sh
@@ -5,6 +5,7 @@ set -e
 sudo apt-get update
 sudo apt-get install -y git iw dnsmasq hostapd screen curl build-essential python3-pip python3-setuptools python3-wheel python3-dev mosquitto haveged net-tools libssl-dev
 
+# NOTE a virtualenv/venv will not work due to the way sudo screen is used to start scripts/servers
 sudo -H python3 -m pip install --upgrade paho-mqtt tornado git+https://github.com/drbild/sslpsk.git pycryptodomex
 
 echo "Ready to start upgrade"


### PR DESCRIPTION
Explain why, and discourage anyone from attempting to use virtualenv/venv.

Current scripts expect global install, flash will fail if venv used.