### PR TITLE
Prevent dnsmasq from reading system config file

### DIFF
--- a/scripts/setup_ap.sh
+++ b/scripts/setup_ap.sh
@@ -43,7 +43,8 @@ setup () {
 		--bind-interfaces \
 		--listen-address=$GATEWAY \
 		--dhcp-range=10.42.42.10,10.42.42.40,12h \
-		--address=/#/$GATEWAY
+		--address=/#/$GATEWAY \
+		--conf-file=../empty.conf
 
 	echo "Starting AP on $WLAN..."
 


### PR DESCRIPTION
Dnsmasq reads the system's config file if it exists. This may prevent dnsmasq to start, or break it otherwise. Providing an empty file ensures that only the command line options are used.