### PR TITLE
Adds WLAN detection and AP password support

### DIFF
--- a/config.txt
+++ b/config.txt
@@ -1,7 +1,12 @@
 # Please input the wlan device to be used (most of the time it is wlan0 or wlan1)
+# Set to "auto" to auto-detection of the 1st wifi device found
 WLAN=wlan0
 
 # Here you could change the WIFI-name but most likely most scripts won't work after
 # Because the WIFI-credentials are hardcoded in the esp8266-ota-flash-convert
 AP=vtrust-flash
 GATEWAY=10.42.42.1
+
+# Uncomment and change the password to set WPA for security for the access point
+# Password should be at least 8 characters long and a mix of uppercase, lowercase and numbers.
+#WPA_PASS=Raspberry

--- a/docker/bin/config.sh
+++ b/docker/bin/config.sh
@@ -2,3 +2,4 @@
 echo WLAN=$WLAN >/usr/bin/tuya-convert/config.txt
 echo AP=$AP >>/usr/bin/tuya-convert/config.txt
 echo GATEWAY=$GATEWAY >>/usr/bin/tuya-convert/config.txt
+echo WPA_PASS=$WPA_PASS >>/usr/bin/tuya-convert/config.txt

--- a/scripts/setup_checks.sh
+++ b/scripts/setup_checks.sh
@@ -2,6 +2,10 @@
 
 # Source config
 . ../config.txt
+if [[ "$WLAN" == "auto" || "$(echo $(iw dev | grep "Interface ") | grep "$WLAN")" ]]; then
+    WLAN=$(echo $(iw dev | grep "Interface ") | cut -d" " -f 2 | head -1)
+    echo "Wireless interface autodetected as $WLAN..."
+fi
 
 check_eula () {
 	if [ ! -f eula_accepted ]; then


### PR DESCRIPTION
This commit uses the 1st wifi device found if the WLAN variable is empty, or if the specified wireless device cannot be found.  It also adds optional WAP password support.