### PR TITLE
Minor fixes for docker execution. Fixes #691

### DIFF
--- a/install_prereq.sh
+++ b/install_prereq.sh
@@ -3,7 +3,7 @@
 set -e
 
 sudo apt-get update
-sudo apt-get install -y git iw dnsmasq hostapd screen curl build-essential python3-pip python3-setuptools python3-wheel python3-dev mosquitto haveged net-tools libssl-dev
+sudo apt-get install -y git iw dnsmasq rfkill hostapd screen curl build-essential python3-pip python3-setuptools python3-wheel python3-dev mosquitto haveged net-tools libssl-dev
 
 sudo -H python3 -m pip install --upgrade paho-mqtt tornado git+https://github.com/drbild/sslpsk.git pycryptodomex
 

--- a/scripts/setup_ap.sh
+++ b/scripts/setup_ap.sh
@@ -42,6 +42,7 @@ setup () {
 		--interface=$WLAN \
 		--bind-interfaces \
 		--listen-address=$GATEWAY \
+		--except-interface=lo \
 		--dhcp-range=10.42.42.10,10.42.42.40,12h \
 		--address=/#/$GATEWAY
 


### PR DESCRIPTION
If you have dnsmasq running on you local machine even though you have explicitly set bind-interfaces listen-interface it would still try to bind to the loopback. So in order to make sure dnsmasq start for the wifi interface event if there is another daemon on the other interfaces we have to explicitly tell it not to bind to localhost