### PR TITLE
updated docker-compose to make building container easier

### DIFF
--- a/docker/docker-compose.sample.yml
+++ b/docker/docker-compose.sample.yml
@@ -1,7 +1,9 @@
 version: '3'
 services:
   tuya:
-    image: tuya:latest
+    build:
+      context: .
+      dockerfile: Dockerfile
     privileged: true
     network_mode: "host"
     environment:


### PR DESCRIPTION
I think having the option to build the containers from docker-compose is cleaner than having to build the base image with docker and then referencing it in docker-compose.yaml. Since the instructions in the readme already require the user to copy docker-compose.sample.yaml to the root directory, it makes sense to allow people to build and run the container using just one command: `docker-compose run tuya start`. 