### PR TITLE
screen<=4.5 generates smarthack-*.log now too

### DIFF
--- a/scripts/old_screen_with_log.sh
+++ b/scripts/old_screen_with_log.sh
@@ -1,0 +1,21 @@
+# Run screen with a custom .screenrc that defines the name of "logfile"
+
+screen_minor=${1}
+screen_logfile_name=${2}
+screen_other_options=${@:3}
+
+if [ "$screen_minor" -gt 5 ]; then
+	echo "Info: you have the modern enough version" \
+             "to use the \"-Logfile\" flag of \"screen\""
+elif [ "$screen_minor" -eq 5 ]; then
+	screen_with_log="sudo screen -L"
+else
+	screen_with_log="sudo screen -L -t"
+fi
+
+echo "logfile ${screen_logfile_name}" > ${screen_logfile_name}.screenrc
+
+${screen_with_log} ${screen_logfile_name} \
+    -c ${screen_logfile_name}.screenrc ${screen_other_options}
+
+rm ${screen_logfile_name}.screenrc

--- a/start_flash.sh
+++ b/start_flash.sh
@@ -10,10 +10,8 @@ setup () {
 	screen_minor=$(screen --version | cut -d . -f 2)
 	if [ "$screen_minor" -gt 5 ]; then
 		screen_with_log="sudo screen -L -Logfile"
-	elif [ "$screen_minor" -eq 5 ]; then
-		screen_with_log="sudo screen -L"
 	else
-		screen_with_log="sudo screen -L -t"
+		screen_with_log="./old_screen_with_log.sh ${screen_minor}"
 	fi
 	echo "======================================================"
 	echo -n "  Starting AP in a screen"


### PR DESCRIPTION
Solve the problem about missing `smarthack-*.log` mentioned in https://github.com/ct-Open-Source/tuya-convert/issues/942 and many others issues