### PR TITLE
updated instructions for docker in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Setup docker-compose:
    * adjust the volume folder, where you want your backups stored
 
 Run the image:
+* it may be necessary to disconnect from your wifi or switch off wifi
 * go into the folder you copied docker-compose.yml
 * docker-compose up -d
 * docker-compose exec tuya start


### PR DESCRIPTION
When trying to flash my devices I was not able to figure out, why I was not able to create the vtrust-AP successfully, when running tuya-convert in the docker container. After a lot of digging through google, I eventually stumbled across https://albert.nz/tuya-convert-esphome/. There was mentioned to switch off wifi to get it to work. I did the same and finally was able to create the vtrust-AP. Thus I suggest to include this step in the instructions.

I do not know, if the same step would also apply to the non-docker-version.