### PR TITLE
Separate prereq install from other files in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,9 @@ RUN echo '* libraries/restart-without-asking boolean true' | sudo debconf-set-se
 
 COPY docker/bin /usr/bin/
 
-COPY . /usr/bin/tuya-convert
-
+COPY install_prereq.sh /usr/bin/tuya-convert/
 RUN cd /usr/bin/tuya-convert && ./install_prereq.sh
 
 RUN mkdir -p /etc/service/tuya && cd /etc/service/tuya && ln -s /usr/bin/config.sh run
+
+COPY . /usr/bin/tuya-convert


### PR DESCRIPTION
Right now any change to any file would retrigger docker build to do a full
prereq install. Given install_prereq.sh has no other dependencies, this changes
it so that file is explicitly added, then prereqs are installed, then other stuff
happens.

That results in faster builds for other tuya file changes.