### PR TITLE
add package providing command `ss` in Ubuntu 22.10

### DIFF
--- a/install_prereq.sh
+++ b/install_prereq.sh
@@ -3,7 +3,7 @@
 set -e
 
 sudo apt-get update
-sudo apt-get install -y git iw dnsmasq rfkill hostapd screen curl build-essential python3-pip python3-setuptools python3-wheel python3-dev mosquitto haveged net-tools libssl-dev
+sudo apt-get install -y git iw dnsmasq rfkill hostapd screen curl build-essential python3-pip python3-setuptools python3-wheel python3-dev mosquitto haveged net-tools libssl-dev iproute2
 
 sudo -H python3 -m pip install --upgrade paho-mqtt tornado git+https://github.com/drbild/sslpsk.git pycryptodomex
 


### PR DESCRIPTION
Added iproute2 as a dependency, which isn't necessarily installed by default in Ubuntu, especially if ubuntu is run as a container with e.g. distrobox