### PR TITLE
use I not S for ping IP

### DIFF
--- a/start_flash.sh
+++ b/start_flash.sh
@@ -73,7 +73,7 @@ while true; do
 	# The intermediate firmware will request 10.42.42.42
 	# Do NOT change this address!!!
 	# It will NOT make it install and will break this script
-	while ! ping -c 1 -W 1 -n 10.42.42.42 -S 10.42.42.1 &> /dev/null; do
+	while ! ping -c 1 -W 1 -n 10.42.42.42 -I 10.42.42.1 &> /dev/null; do
 		printf .
 		if (( --i == 0 )); then
 			echo


### PR DESCRIPTION
newer version of ubuntu/kali/debian use `-S` as a packet size and NOT an IP SOURCE
so change to `-I` instead works