### PR TITLE
fix: mosquitto only listens on localhost when started without a conf file

### DIFF
--- a/scripts/mosquitto.conf
+++ b/scripts/mosquitto.conf
@@ -1,0 +1,2 @@
+allow_anonymous true
+listener 1883

--- a/start_flash.sh
+++ b/start_flash.sh
@@ -26,7 +26,7 @@ setup () {
 	echo "  Starting web server in a screen"
 	$screen_with_log smarthack-web.log -S smarthack-web -m -d ./fake-registration-server.py
 	echo "  Starting Mosquitto in a screen"
-	$screen_with_log smarthack-mqtt.log -S smarthack-mqtt -m -d mosquitto -v
+	$screen_with_log smarthack-mqtt.log -S smarthack-mqtt -m -d mosquitto -v -c $PWD/scripts/mosquitto.conf
 	echo "  Starting PSK frontend in a screen"
 	$screen_with_log smarthack-psk.log -S smarthack-psk -m -d ./psk-frontend.py -v
 	echo "  Starting Tuya Discovery in a screen"


### PR DESCRIPTION
Modern versions of mosquitto only listen on localhost when started by commandline without a conf file. This prevents network devices (such as the target TUYA device) from accessing the MQTT server, thus failing the intermediate firmware flash causing start_flash.sh to eventually time out.

This PR addresses the above issue by adding a minimal mosquitto.conf that defines a listener, allowing network access to mosquitto