### PR TITLE
"master" is not a version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM phusion/baseimage:master
+FROM phusion/baseimage:jammy-1.0.1
 
 RUN apt-get update && apt-get install -y sudo iproute2 iputils-ping
 


### PR DESCRIPTION
Look at https://hub.docker.com/r/phusion/baseimage/tags, `master` is not listed.