### PR TITLE
Update hostapd.conf

### DIFF
--- a/scripts/hostapd.conf
+++ b/scripts/hostapd.conf
@@ -1,5 +1,6 @@
 # interface file to control hostapd from tuya-convert
 ctrl_interface=hostapd_ctrl
+driver=nl80211
 
 # our AP SSID
 ssid=vtrust-flash


### PR DESCRIPTION
After testing on serval devices I found that the AP would fail to start with an error from hostapd stating "failed to set beacon parameters" after setting the driver in the hostapd.conf the access point starts up and works as expected.

This changes is to make these driver the default behaviour.