### PR TITLE
Add hint to disconnect AP-Mode adapter from all networks to REAME.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Troubleshooting:
 * Q: I want to rebuild my docker-image, even if there are no changes. Is this possible? A: Just start `docker-compose build --no-cache` instead of `docker-compose build`! Don't do this all the time, this is a time consuming process ...
 * Q: I can't connect to my USB, PCI, ... network card. How do I get this working? A: You may have an error in your .env-File. The WLAN-variable should reflect the name of your network interface on your host. Execute ifconfig and look through your interfaces.
 * Q: I can't get an IP-address and or connection on my phone, what's the problem? A: You may look into smarthack-wifi.log (location is set in .env with LOCALBACKUPDIR) or possible stop your firewall (e.g. NixOS seems to have a problem here). It may be a problem with a wrongly set network interface (see previous question)
+* Q: The tool gets stuck on starting AP in a screen...? Ensure the WiFi card used for the procedure is not connected to any other WiFi network (disconnect and disable auto-connect / remove saved networks), and use a different network adapter (e.g., LAN or another WiFi card) for SSH access if needed.
 
 ## CONTRIBUTING
 


### PR DESCRIPTION
Got stuck in an endless dot-loop after "starting AP in a screen...." and didn't know what was wrong.

Turns out, I accidentally flashed some old pre-configuration with the Raspberry Pi Imager, that made the pi connect to my WiFi network even though I thought, it'd only be connected via LAN.

After reading through some of the issues, I found the solution in https://github.com/ct-Open-Source/tuya-convert/issues/1025 .

I thought it might make sense to include a hint about double checking the wifi adapters connections in the troubleshooting section.