### PR TITLE
Configurable mqtt/mqtts ports

### DIFF
--- a/.env-template
+++ b/.env-template
@@ -4,3 +4,5 @@ WLAN=wlan0                          #must match the name of your wlan-interface 
 AP=vtrust-flash                     #the name of the created AP, can be anything you want
 GATEWAY=10.42.42.1                  #gateway address, leave it here
 LOCALBACKUPDIR=./data/backups       #location on your host where you want to store backuos of the old firmware & logs
+MQTT_PORT=1883                      #MQTT broker port, change if your host already has MQTT on 1883
+MQTTS_PORT=8886                     #MQTTS broker port, change if your host already has MQTTS on 8886

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.13
 
-RUN apk add --update bash git iw dnsmasq hostapd screen curl py3-pip py3-wheel python3-dev mosquitto haveged net-tools openssl openssl-dev gcc musl-dev linux-headers sudo coreutils grep iproute2 ncurses
+RUN apk add --update bash git iw dnsmasq hostapd screen curl py3-pip py3-wheel python3-dev mosquitto haveged net-tools openssl openssl-dev gcc musl-dev linux-headers sudo coreutils grep iproute2 ncurses gettext
 
 RUN python3 -m pip install --upgrade paho-mqtt tornado git+https://github.com/drbild/sslpsk.git pycryptodomex
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Preparations:
 * if you have already cloned this repo just cd into the directory and execute `git pull`
 * cp .env-template .env 
 * adjust the created .env-file, it contains usage information as comments
+* (Optional) if your host already has an MQTT broker on port 1883, you can set `MQTT_PORT` in your .env file to use a different port (e.g. `MQTT_PORT=1884`)
 
 Building and running your container:
 * `docker-compose build && docker-compose run --rm tuya`

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Preparations:
 * if you have already cloned this repo just cd into the directory and execute `git pull`
 * cp .env-template .env 
 * adjust the created .env-file, it contains usage information as comments
-* (Optional) if your host already has an MQTT broker on port 1883, you can set `MQTT_PORT` in your .env file to use a different port (e.g. `MQTT_PORT=1884`)
+* (Optional) if your host already has MQTT/MQTTS brokers running, you can set `MQTT_PORT` and/or `MQTTS_PORT` in your .env file to use different ports (e.g. `MQTT_PORT=1884` and `MQTTS_PORT=8887`)
 
 Building and running your container:
 * `docker-compose build && docker-compose run --rm tuya`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,5 +9,6 @@ services:
         AP: ${AP}
         GATEWAY: ${GATEWAY}
         MQTT_PORT: ${MQTT_PORT:-1883}
+        MQTTS_PORT: ${MQTTS_PORT:-8886}
     volumes:
       - $LOCALBACKUPDIR:/usr/bin/tuya-convert/backups

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,5 +8,6 @@ services:
         WLAN: ${WLAN}
         AP: ${AP}
         GATEWAY: ${GATEWAY}
+        MQTT_PORT: ${MQTT_PORT:-1883}
     volumes:
       - $LOCALBACKUPDIR:/usr/bin/tuya-convert/backups

--- a/scripts/psk-frontend.py
+++ b/scripts/psk-frontend.py
@@ -4,6 +4,7 @@ import socket
 import select
 import ssl
 import sslpsk
+import os
 
 from Cryptodome.Cipher import AES
 from hashlib import md5
@@ -96,7 +97,10 @@ class PskFrontend():
 
 def main():
 	gateway = '10.42.42.1'
-	proxies = [PskFrontend(gateway, 443, gateway, 80), PskFrontend(gateway, 8886, gateway, 1883)]
+	mqtt_port = int(os.environ.get('MQTT_PORT', 1883))
+	proxies = [PskFrontend(gateway, 443, gateway, 80), PskFrontend(gateway, 8886, gateway, mqtt_port)]
+
+	print(f"PSK frontend configured with MQTT port: {mqtt_port}")
 
 
 	while True:

--- a/scripts/psk-frontend.py
+++ b/scripts/psk-frontend.py
@@ -98,9 +98,10 @@ class PskFrontend():
 def main():
 	gateway = '10.42.42.1'
 	mqtt_port = int(os.environ.get('MQTT_PORT', 1883))
-	proxies = [PskFrontend(gateway, 443, gateway, 80), PskFrontend(gateway, 8886, gateway, mqtt_port)]
+	mqtts_port = int(os.environ.get('MQTTS_PORT', 8886))
+	proxies = [PskFrontend(gateway, 443, gateway, 80), PskFrontend(gateway, mqtts_port, gateway, mqtt_port)]
 
-	print(f"PSK frontend configured with MQTT port: {mqtt_port}")
+	print(f"PSK frontend configured with MQTT port: {mqtt_port}, MQTTS port: {mqtts_port}")
 
 
 	while True:

--- a/scripts/setup_checks.sh
+++ b/scripts/setup_checks.sh
@@ -143,7 +143,8 @@ check_port udp 6666 "detect unencrypted Tuya firmware"
 check_port udp 6667 "detect encrypted Tuya firmware"
 MQTT_PORT=${MQTT_PORT:-1883}
 check_port tcp $MQTT_PORT "run MQTT"
-check_port tcp 8886 "run MQTTS"
+MQTTS_PORT=${MQTTS_PORT:-8886}
+check_port tcp $MQTTS_PORT "run MQTTS"
 check_firewall
 check_blacklist
 

--- a/scripts/setup_checks.sh
+++ b/scripts/setup_checks.sh
@@ -141,7 +141,8 @@ check_port tcp 80 "answer HTTP requests"
 check_port tcp 443 "answer HTTPS requests"
 check_port udp 6666 "detect unencrypted Tuya firmware"
 check_port udp 6667 "detect encrypted Tuya firmware"
-check_port tcp 1883 "run MQTT"
+MQTT_PORT=${MQTT_PORT:-1883}
+check_port tcp $MQTT_PORT "run MQTT"
 check_port tcp 8886 "run MQTTS"
 check_firewall
 check_blacklist

--- a/start_flash.sh
+++ b/start_flash.sh
@@ -6,6 +6,15 @@ normal=$(tput sgr0)
 setup () {
 	echo "tuya-convert $(git describe --tags)"
 	pushd scripts >/dev/null || exit
+	
+	# Generate mosquitto.conf with configurable port
+	MQTT_PORT=${MQTT_PORT:-1883}
+	cat > mosquitto.conf <<EOF
+allow_anonymous true
+listener $MQTT_PORT
+EOF
+	echo "  Mosquitto configured to listen on port $MQTT_PORT"
+	
 	. ./setup_checks.sh
 	screen_minor=$(screen --version | cut -d . -f 2)
 	if [ "$screen_minor" -gt 5 ]; then


### PR DESCRIPTION
Hi, since this tools makes access to the host network - where other MQTT/MQTTS brokers could sit - here I'm making the MQTT/MQTTS ports configurable via the .env file, avoiding conflicts with the tuya-convert internal broker.